### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -6,6 +6,10 @@ on:
       tag:
         description: "Tag for the release"
         required: true
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -20,3 +24,4 @@ jobs:
     uses: step-security/reusable-workflows/.github/workflows/actions_release.yaml@v1
     with:
       tag: "${{ github.event.inputs.tag }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -11,6 +11,10 @@ on:
         description: "Specify a base branch"
         required: false
         default: "main"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -20,6 +24,7 @@ jobs:
     with:
       force: ${{ inputs.force || false }}
       base_branch: ${{ inputs.base_branch || 'main' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Pull Request Comment Trigger
 
 A GitHub Action that monitors pull request descriptions and comments for specific trigger phrases, enabling conditional workflow execution based on comment content.

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ outputs:
   comment_body:
     description: The full text content of the comment or pull request description that was analyzed for triggers.
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: check-circle

--- a/dist/index.js
+++ b/dist/index.js
@@ -44640,24 +44640,54 @@ module.exports = /*#__PURE__*/JSON.parse('{"application/1d-interleaved-parityfec
 /************************************************************************/
 var __webpack_exports__ = {};
 
+const fs = __nccwpck_require__(9896);
 const core = __nccwpck_require__(7484);
 const { context, getOctokit} = __nccwpck_require__(3228);
 const axios = __nccwpck_require__(7269)
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "Khan/pull-request-comment-trigger";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("\u001b[1;36mStepSecurity Maintained Action\u001b[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("\u001b[32m\u2713 Free for public repositories\u001b[0m");
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000})
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
     if (axios.isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
-      )
-      process.exit(1)
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.')
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`,
+      );
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`,
+      );
+      process.exit(1);
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,23 +1,53 @@
 #!/usr/bin/env node
 
+const fs = require("fs");
 const core = require("@actions/core");
 const { context, getOctokit} = require("@actions/github");
 const axios = require("axios")
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "Khan/pull-request-comment-trigger";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("\u001b[1;36mStepSecurity Maintained Action\u001b[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("\u001b[32m\u2713 Free for public repositories\u001b[0m");
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000})
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
     if (axios.isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
-      )
-      process.exit(1)
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.')
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`,
+      );
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`,
+      );
+      process.exit(1);
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24
- Updated workflow files with configurable node_version input
- Removed GuardDog workflow

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated workflow files, rebuilt dist/

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T051539Z